### PR TITLE
🌟 new: First pass at converting page furniture to partials

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+bower_components/
+demos/local

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,41 @@
+{
+  "ecmaFeatures": {
+    "modules": true
+  },
+  parserOptions: {
+    sourceType: "module"
+  },
+  "env": {
+    "es6": true,
+    "browser": true
+  },
+  "rules": {
+    "no-unused-vars": 2,
+    "no-undef": 2,
+    "eqeqeq": 2,
+    "guard-for-in": 2,
+    "no-extend-native": 2,
+    "wrap-iife": 2,
+    "new-cap": 2,
+    "no-caller": 2,
+    "no-multi-str": 0,
+    "dot-notation": 0,
+    "semi": [2, "always"],
+    "strict": [2, "global"],
+    "valid-jsdoc": 1,
+    "no-irregular-whitespace": 1,
+    "no-multi-spaces": 2,
+    "one-var": [2, "never"],
+    "constructor-super": 2,
+    "no-this-before-super": 2,
+    "no-var": 2,
+    "prefer-const": 1,
+    "no-const-assign": 2
+  },
+  "globals": {
+    "require": false,
+    "module": false,
+    "exports": false,
+    "requireText": false
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "ig-article",
-  "main": ["main.js", "main.scss"],
+  "main": [
+    "main.js",
+    "main.scss"
+  ],
   "ignore": [
     ".travis.yml",
     "circle.yml"

--- a/demos/src/index.mustache
+++ b/demos/src/index.mustache
@@ -1,19 +1,5 @@
-<!-- START : SITE HEADER -->
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-header@^5">
-<header class="o-header o-header--minimal o-header--light" data-o-component="o-header" data-o-header--js="">
-<div class="o-header__container">
-  <div class="o-header__inner">
-    <div class="o-header__bottom" data-o-header-suggestions="">
-      <div class="o-header__masthead-mobile">
-        <a href="http://www.ft.com/" title="Go to Financial Times homepage"><span>Financial Times</span></a>
-      </div>
-    </div>
-  </div>
-</div>
-</header>
-<script src="https://origami-build.ft.com/v2/bundles/js?modules=o-header@^5"></script>
-<!-- END : SITE HEADER -->
-
+<script src="demo.js"></script>
+<header id="ig-header"></header>
 
 <main role="main">
   <article>
@@ -143,84 +129,4 @@
   </article>
 </main>
 
-<!-- START : SITE FOOTER -->
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-footer@^4">
-<footer class="footer" role="contentinfo">
-  <div class="o-footer o-footer--theme-light" data-o-component="o-footer">
-    <div class="o-footer__container">
-      <nav class="o-footer__row o-footer__nav">
-        <div class="o-footer__col o-footer__col--full-width">
-          <h3 class="o-footer__title">Sections</h3>
-          <ul class="o-footer__row o-footer__section-list">
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com">Home</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/world/uk">UK</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/world">World</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/companies">Companies</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/markets">Markets</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/global-economy">Global Economy</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/lex">Lex</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/comment">Comment</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/management">Management</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/personal-finance">Personal Finance</a></li>
-            <li class="o-footer__link o-footer__section-link o-footer__col"><a href="http://www.ft.com/life-arts">Life &amp; Arts</a></li>
-          </ul>
-          <div class="o-footer__divider"></div>
-        </div>
-      </nav>
-      <div class="o-footer__row o-footer__link-lists">
-        <nav class="o-footer__col o-footer__link-list">
-          <h3 class="o-footer__title">Tools</h3>
-          <ul>
-              <li class="o-footer__link"><a href="http://portfolio.ft.com/">Portfolio</a></li>
-              <li class="o-footer__link"><a href="http://lexicon.ft.com/">Lexicon</a></li>
-              <li class="o-footer__link"><a href="http://www.ft.com/topics">Topics</a></li>
-              <li class="o-footer__link"><a href="http://markets.ft.com/alerts/keyword.asp">Alerts Hub</a></li>
-              <li class="o-footer__link"><a href="http://nbe.ft.com/nbe/profile.cfm?segid=70121">Daily Briefings</a></li>
-          </ul>
-        </nav>
-        <nav class="o-footer__col o-footer__link-list">
-          <h3 class="o-footer__title">Services</h3>
-          <ul>
-              <li class="o-footer__link"><a href="http://www.ft.com/corporate">Corporate subscriptions</a></li>
-              <li class="o-footer__link"><a href="http://www.ft.com/syndication">Syndication</a></li>
-              <li class="o-footer__link"><a href="https://www.ft-live.com/">Conferences</a></li>
-          </ul>
-        </nav>
-        <nav class="o-footer__col o-footer__link-list">
-          <h3 class="o-footer__title">Support</h3>
-          <ul>
-              <li class="o-footer__link"><a href="http://www.ft.com/help">Help</a></li>
-              <li class="o-footer__link"><a href="http://www.ft.com/aboutus">About us</a></li>
-              <li class="o-footer__link"><a href="http://aboutus.ft.com/careers/">Jobs</a></li>
-              <li class="o-footer__link"><a href="http://aboutus.ft.com/contact-us">Contact us</a></li>
-          </ul>
-        </nav>
-        <nav class="o-footer__col o-footer__link-list">
-          <h3 class="o-footer__title">Legal &amp; Advertising</h3>
-          <ul>
-              <li class="o-footer__link"><a href="http://www.ft.com/advertising">Advertise with the FT</a></li>
-              <li class="o-footer__link"><a href="http://www.ft.com/servicestools/help/terms">Terms &amp; conditions</a></li>
-              <li class="o-footer__link"><a href="http://www.ft.com/servicestools/help/privacy">Cookie &amp; privacy policy</a></li>
-              <li class="o-footer__link"><a href="http://www.ft.com/servicestools/help/copyright">Copyright</a></li>
-          </ul>
-        </nav>
-      </div>
-      <div class="o-footer__row o-footer__copyright">
-        <div class="o-footer__col o-footer__col--full-width">
-          <span>&#xA9; THE FINANCIAL TIMES LTD 2016.</span>
-          <span><abbr title="Financial Times">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.</span>
-        </div>
-      </div>
-    </div>
-    <div class="o-footer__brand">
-      <div class="o-footer__container">
-        <div class="o-footer__row">
-          <div class="o-footer__col o-footer__col--full-width">
-            <div class="o-footer__brand-logo" aria-label="A Nikkei Company"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</footer>
-<!-- END : SITE FOOTER -->
+<footer id="ig-footer"></footer>

--- a/js/demo.js
+++ b/js/demo.js
@@ -1,0 +1,11 @@
+import igArticle from './index';
+Promise.all([
+  fetch('/partials/header.html'),
+  fetch('/partials/footer.html')
+]).then(([header, footer]) => {
+  Promise.all([header.text(), footer.text()]).then(([header, footer]) => {
+    document.getElementById('ig-header').innerHTML = header;
+    document.getElementById('ig-footer').innerHTML = footer;
+    igArticle.init();
+  });
+});

--- a/js/index.js
+++ b/js/index.js
@@ -1,1 +1,13 @@
 export default function igArticle(){};
+
+igArticle.init = function() {
+  // Set isNext global / body class based on user site preference
+  window.isNext = /FT_SITE=NEXT/.test(document.cookie);
+  document.body.classList.add(window.isNext && window.isNext === 'NEXT' ? 'is-next' : 'is-falcon');
+
+  // Add .js-loaded body class, remove all .wait-for-js classes.
+  document.body.classList.add('js-loaded');
+  Array.prototype.forEach.call(document.querySelectorAll('.wait-for-js'), function( el ){
+    el.classList.remove('wait-for-js');
+  });
+};

--- a/main.js
+++ b/main.js
@@ -1,11 +1,12 @@
-import oShare from 'o-share';
+// import oShare from 'o-share'; // Importing o-share causes a registerElement duplication error.
 import oDate from 'o-date';
 import igArticle from './js/index';
 
 const constructAll = () => {
-	oShare.init();
-	oDate.init();
-	document.removeEventListener('o.DOMContentLoaded', constructAll);
+  // oShare.init();
+  oDate.init();
+  igArticle.init();
+  document.removeEventListener('o.DOMContentLoaded', constructAll);
 };
 
 document.addEventListener('o.DOMContentLoaded', constructAll);

--- a/origami.json
+++ b/origami.json
@@ -6,6 +6,7 @@
 	"supportStatus": "experimental",
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
+		"js": ["js/demo.js"],
 		"dependencies": ["o-fonts@^2", "o-grid@^4"]
 	},
 	"ci": {
@@ -14,9 +15,10 @@
 	"demos": [
 		{
 			"name": "article",
-			"template": "demos/src/index.html",
+			"template": "demos/src/index.mustache",
 			"expanded": true,
-			"description": ""
+			"description": "",
+			"js": "/js/demo.js"
 		}
   ]
 }

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,156 @@
+<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-footer@^4">
+<footer class="o-footer o-footer--variant-next wait-for-js" data-o-component="o-footer">
+	<div class="o-footer__container">
+		<nav class="o-footer__row o-footer__nav">
+			<div class="o-footer__col o-footer__col--full-width">
+				<h3 class="o-footer__title">Sections</h3>
+				<ul class="o-footer__row o-footer__section-list">
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com">Home</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/world/uk">UK</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/world">World</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/companies">Companies</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/markets">Markets</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/global-economy">Global Economy</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/lex">Lex</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/comment">Comment</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/management">Management</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/personal-finance">Personal Finance</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/life-arts">Life &amp; Arts</a></li>
+				</ul>
+				<div class="o-footer__divider"></div>
+			</div>
+		</nav>
+		<div class="o-footer__row o-footer__link-lists">
+			<nav class="o-footer__col o-footer__link-list">
+				<h3 class="o-footer__title">Services</h3>
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Corporate subscriptions</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Syndication</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Conferences</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Corporate subscriptions</a></li>
+				</ul>
+			</nav>
+			<nav class="o-footer__col o-footer__link-list">
+
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Syndication</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Conferences</a></li>
+						<li class="o-footer__link"><a href="//ft.com">FT Collection</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Jobs</a></li>
+				</ul>
+			</nav>
+			<nav class="o-footer__col o-footer__link-list">
+				<h3 class="o-footer__title">Support</h3>
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Help</a></li>
+						<li class="o-footer__link"><a href="//ft.com">About us</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Site tour</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Contact us</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Sitemap</a></li>
+				</ul>
+			</nav>
+			<nav class="o-footer__col o-footer__link-list">
+				<h3 class="o-footer__title">Legal &amp; Advertising</h3>
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Advertise with the FT</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Terms &amp; conditions</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Cookie &amp; privacy policy</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Copyright</a></li>
+				</ul>
+			</nav>
+		</div>
+		<div class="o-footer__row o-footer__copyright">
+			<div class="o-footer__col o-footer__col--full-width">
+				<span>&#xA9; THE FINANCIAL TIMES LTD 2016.</span>
+				<span><abbr title="Financial Times">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.</span>
+			</div>
+		</div>
+	</div>
+	<div class="o-footer__brand">
+		<div class="o-footer__container">
+			<div class="o-footer__row">
+				<div class="o-footer__col o-footer__col--full-width">
+					<div class="o-footer__brand-logo" aria-label="A Nikkei Company"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+</footer>
+
+<footer class="o-footer o-footer--theme-light o-footer--variant-falcon wait-for-js" data-o-component="o-footer">
+	<div class="o-footer__container">
+		<nav class="o-footer__row o-footer__nav">
+			<div class="o-footer__col o-footer__col--full-width">
+				<h3 class="o-footer__title">Sections</h3>
+				<ul class="o-footer__row o-footer__section-list">
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com">Home</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/world/uk">UK</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/world">World</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/companies">Companies</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/markets">Markets</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/global-economy">Global Economy</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/lex">Lex</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/comment">Comment</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/management">Management</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/personal-finance">Personal Finance</a></li>
+					<li class="o-footer__link o-footer__section-link o-footer__col"><a href="//www.ft.com/life-arts">Life &amp; Arts</a></li>
+				</ul>
+				<div class="o-footer__divider"></div>
+			</div>
+		</nav>
+		<div class="o-footer__row o-footer__link-lists">
+			<nav class="o-footer__col o-footer__link-list">
+				<h3 class="o-footer__title">Services</h3>
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Corporate subscriptions</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Syndication</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Conferences</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Corporate subscriptions</a></li>
+				</ul>
+			</nav>
+			<nav class="o-footer__col o-footer__link-list">
+
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Syndication</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Conferences</a></li>
+						<li class="o-footer__link"><a href="//ft.com">FT Collection</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Jobs</a></li>
+				</ul>
+			</nav>
+			<nav class="o-footer__col o-footer__link-list">
+				<h3 class="o-footer__title">Support</h3>
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Help</a></li>
+						<li class="o-footer__link"><a href="//ft.com">About us</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Site tour</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Contact us</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Sitemap</a></li>
+				</ul>
+			</nav>
+			<nav class="o-footer__col o-footer__link-list">
+				<h3 class="o-footer__title">Legal &amp; Advertising</h3>
+				<ul>
+						<li class="o-footer__link"><a href="//ft.com">Advertise with the FT</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Terms &amp; conditions</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Cookie &amp; privacy policy</a></li>
+						<li class="o-footer__link"><a href="//ft.com">Copyright</a></li>
+				</ul>
+			</nav>
+		</div>
+		<div class="o-footer__row o-footer__copyright">
+			<div class="o-footer__col o-footer__col--full-width">
+				<span>&#xA9; THE FINANCIAL TIMES LTD 2016.</span>
+				<span><abbr title="Financial Times">FT</abbr> and &#x2018;Financial Times&#x2019; are trademarks of The Financial Times Ltd.</span>
+			</div>
+		</div>
+	</div>
+	<div class="o-footer__brand">
+		<div class="o-footer__container">
+			<div class="o-footer__row">
+				<div class="o-footer__col o-footer__col--full-width">
+					<div class="o-footer__brand-logo" aria-label="A Nikkei Company"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,13 @@
+<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-header@^5">
+<header class="o-header o-header--minimal o-header--light wait-for-js" data-o-component="o-header" data-o-header--js="">
+<div class="o-header__container">
+  <div class="o-header__inner">
+    <div class="o-header__bottom" data-o-header-suggestions="">
+      <div class="o-header__masthead-mobile">
+        <a href="http://www.ft.com/" title="Go to Financial Times homepage"><span>Financial Times</span></a>
+      </div>
+    </div>
+  </div>
+</div>
+</header>
+<script src="https://origami-build.ft.com/v2/bundles/js?modules=o-header@^5"></script>

--- a/scss/core/_utils.scss
+++ b/scss/core/_utils.scss
@@ -1,0 +1,13 @@
+.is-next {
+  .hide-next {
+    display: none !important;
+  }
+}
+
+.is-falcon {
+  .hide-falcon { display: none !important;}
+}
+
+.wait-for-js {
+  display: none !important;
+}

--- a/scss/origami-overrides/_o-footer.scss
+++ b/scss/origami-overrides/_o-footer.scss
@@ -1,1 +1,20 @@
 // nothing to override
+.is-falcon {
+  .o-footer--variant-next {
+    display: none;
+  }
+
+  .o-footer--variant-falcon {
+    display: initial;
+  }
+}
+
+.is-next {
+  .o-footer--variant-falcon {
+    display: none;
+  }
+
+  .o-footer--variant-next {
+    display: inital;
+  }
+}


### PR DESCRIPTION
~~This adds jQuery and Mustache as Bower dev-dependencies so they can load the header and footer as partial HTML files in the demo.~~ This PR extracts the header and footer into partial templates, meaning they can be independently included in `ft-interactive/starter-kit` via `gulp-html-tag-include`.

It also selectively shows/hides the dark/light version of the footer based on whether the client has a `FT_SITE=NEXT` cookie set (respectively).
