### PR TITLE
Switch from geebee to new image service

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -57,8 +57,8 @@ $o-grid-is-silent: false;
 }
 
 .header__link:after {
-  background-image: url("https://next-geebee.ft.com/image/v1/images/raw/fticon:arrow-right?source=o-icons&tint=%2327757B,%2327757B&format=svg");
-  background-image: url("https://next-geebee.ft.com/image/v1/images/raw/fticon:arrow-right?source=o-icons&tint=%2327757B,%2327757B&format=png&width=16")\9;
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%2327757B&format=svg");
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%2327757B&format=png&width=16")\9;
   display: inline-block;
   content: '';
   position: absolute;
@@ -75,8 +75,8 @@ $o-grid-is-silent: false;
   vertical-align: baseline;
 }
 .header__link:hover:after {
-  background-image: url("https://next-geebee.ft.com/image/v1/images/raw/fticon:arrow-right?source=o-icons&tint=%23333333,%23333333&format=svg");
-  background-image: url("https://next-geebee.ft.com/image/v1/images/raw/fticon:arrow-right?source=o-icons&tint=%23333333,%23333333&format=png&width=16")\9;
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%23333333&format=svg");
+  background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon:arrow-right?source=o-icons&tint=%23333333&format=png&width=16")\9;
   display: inline-block;
 }
 

--- a/demos/src/index.mustache
+++ b/demos/src/index.mustache
@@ -20,7 +20,7 @@
 
     <div class="block">
       <figure class="viz viz--letterbox">
-        <img class="viz__image viz--offsetmaster" alt="" src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
+        <img class="viz__image viz--offsetmaster" alt="" src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
       </figure>
     </div>
 
@@ -112,7 +112,7 @@
         beginning of this article. </p>
 
         <figure class="block block--b1 viz viz--master">
-          <img class="viz__image" alt="" src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
+          <img class="viz__image" alt="" src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fcom.ft.imagepublish.prod.s3.amazonaws.com%2Fc4bf0be4-7c15-11e4-a7b8-00144feabdc0?source=ig&fit=scale-down&width=700"></img>
             <figcaption class="figure__caption figure__caption--inside o-typography-caption">
             <a class="o-typography-link" href="#void">&#xA9;Credit person</a> George Orwell at his typewriter
           </figcaption>

--- a/demos/src/onwardjourney.mustache
+++ b/demos/src/onwardjourney.mustache
@@ -1,11 +1,11 @@
 <div class="o-grid-container">
   <div class="container o-grid-row">
-   
+
 
     <!-- first block -->
     <div data-o-grid-colspan="12 center">
       <h1>Option 1</h1>
-        <div class="o-grid-row"> 
+        <div class="o-grid-row">
           <div data-o-grid-colspan="12">
             <div class="header">
               <span class="header__title">
@@ -17,11 +17,11 @@
             </div>
           </div>
         </div>
-        <div class="o-grid-row"> 
+        <div class="o-grid-row">
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -36,7 +36,7 @@
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -53,7 +53,7 @@
               <div class="o-card__content o-card__content-">
                 <div class="o-card__meta">
                     <div class="o-card__meta-image o-card__meta-image--rounded">
-                      <img src="http://image.webservices.ft.com/v1/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
+                      <img src="http://www.ft.com/__origami/service/image/v2/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
                     </div>
                   <a href="#" class="o-card__tag">Mrs Moneypenny</a>
                 </div>
@@ -66,7 +66,7 @@
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -81,7 +81,7 @@
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -96,7 +96,7 @@
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -111,7 +111,7 @@
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -126,7 +126,7 @@
           <div data-o-grid-colspan="12 S6 M4 XL3">
             <div class="o-card o-card--image-" data-o-component="o-card">
               <div class="o-card__image o-card__image--">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -138,12 +138,12 @@
               </div>
             </div>
           </div>
-        </div> 
+        </div>
       </div>
  <!-- first block small -->
     <div data-o-grid-colspan="12 center">
       <h1>Option 1 -- small</h1>
-        <div class="o-grid-row"> 
+        <div class="o-grid-row">
           <div data-o-grid-colspan="12">
             <div class="header">
               <span class="header__title">
@@ -155,11 +155,11 @@
             </div>
           </div>
         </div>
-        <div class="o-grid-row"> 
+        <div class="o-grid-row">
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -174,7 +174,7 @@
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -191,7 +191,7 @@
               <div class="o-card__content o-card__content-">
                 <div class="o-card__meta">
                     <div class="o-card__meta-image o-card__meta-image--rounded">
-                      <img src="http://image.webservices.ft.com/v1/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
+                      <img src="http://www.ft.com/__origami/service/image/v2/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
                     </div>
                   <a href="#" class="o-card__tag">Mrs Moneypenny</a>
                 </div>
@@ -204,7 +204,7 @@
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -219,7 +219,7 @@
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -234,7 +234,7 @@
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -249,7 +249,7 @@
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -264,7 +264,7 @@
           <div data-o-grid-colspan="12 S6 L4 XL3">
             <div class="o-card o-card--landscape o-card--image-right" data-o-component="o-card">
               <div class="o-card__image o-card__image--right">
-                <img src="https://image.webservices.ft.com/v1/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
+                <img src="https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?source=o-card-demo" alt="demo image"></img>
               </div>
               <div class="o-card__content">
                 <div class="o-card__meta">
@@ -276,13 +276,13 @@
               </div>
             </div>
           </div>
-        </div> 
+        </div>
       </div>
     </div>
 
     <div data-o-grid-colspan="12 center">
       <h1>Option 2</h1>
-      <div class="o-grid-row"> 
+      <div class="o-grid-row">
           <div data-o-grid-colspan="12">
             <div class="header">
               <span class="header__title">
@@ -294,7 +294,7 @@
             </div>
           </div>
         </div>
-        <div class="o-grid-row"> 
+        <div class="o-grid-row">
           <div data-o-grid-colspan="12 S6 M4">
             <div class="o-card" data-o-component="o-card">
               <div class="o-card__content">
@@ -324,7 +324,7 @@
               <div class="o-card__content o-card__content-">
                 <div class="o-card__meta">
                     <div class="o-card__meta-image o-card__meta-image--rounded">
-                      <img src="http://image.webservices.ft.com/v1/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
+                      <img src="http://www.ft.com/__origami/service/image/v2/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
                     </div>
                   <a href="#" class="o-card__tag">Mrs Moneypenny</a>
                 </div>
@@ -371,11 +371,11 @@
             </div>
           </div>
         </div>
-      </div> 
+      </div>
 
     <div data-o-grid-colspan="12 center">
       <h1>Option 2 -- small</h1>
-      <div class="o-grid-row"> 
+      <div class="o-grid-row">
           <div data-o-grid-colspan="12">
             <div class="header">
               <span class="header__title">
@@ -387,7 +387,7 @@
             </div>
           </div>
         </div>
-        <div class="o-grid-row"> 
+        <div class="o-grid-row">
           <div data-o-grid-colspan="12 S6 M4 L3">
             <div class="o-card" data-o-component="o-card">
               <div class="o-card__content">
@@ -417,7 +417,7 @@
               <div class="o-card__content o-card__content-">
                 <div class="o-card__meta">
                     <div class="o-card__meta-image o-card__meta-image--rounded">
-                      <img src="http://image.webservices.ft.com/v1/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
+                      <img src="http://www.ft.com/__origami/service/image/v2/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60" alt=" "></img>
                     </div>
                   <a href="#" class="o-card__tag">Mrs Moneypenny</a>
                 </div>
@@ -487,7 +487,7 @@
               </div>
             </div>
           </div>
-        </div> 
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2